### PR TITLE
Resources for de-DE (German)

### DIFF
--- a/Community.PowerToys.Run.Plugin.Everything.csproj
+++ b/Community.PowerToys.Run.Plugin.Everything.csproj
@@ -82,6 +82,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.de-de.resx">
+      <CustomToolNamespace>Community.PowerToys.Run.Plugin.Everything.Language</CustomToolNamespace>
+      <LastGenOutput>Resources.de.Designer.cs</LastGenOutput>
+      <Generator>PublicResXFileCodeGenerator</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Properties\Resources.zh-cn.resx">
       <CustomToolNamespace>Community.PowerToys.Run.Plugin.Everything.Language</CustomToolNamespace>
       <LastGenOutput>Resources - Copy.zh.Designer.cs</LastGenOutput>

--- a/Properties/Resources.de-de.resx
+++ b/Properties/Resources.de-de.resx
@@ -1,0 +1,186 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="clipboard_failed" xml:space="preserve">
+    <value>Text konnte nicht in die Zwischenablage kopiert werden</value>
+  </data>
+  <data name="copy_file" xml:space="preserve">
+    <value>Kopieren (Ctrl+C)</value>
+  </data>
+  <data name="copy_path" xml:space="preserve">
+    <value>Pfad kopieren (Ctrl+C)</value>
+  </data>
+  <data name="Everything_ini" xml:space="preserve">
+    <value>Everything installieren falls es nicht installiert ist</value>
+  </data>
+  <data name="Everything_not_running" xml:space="preserve">
+    <value>Everything wird nicht ausgeführt</value>
+  </data>
+  <data name="folder_open_failed" xml:space="preserve">
+    <value>Ordner konnte nicht geöffnet werden: </value>
+  </data>
+  <data name="Match_path" xml:space="preserve">
+    <value>Pfad beachten</value>
+  </data>
+  <data name="Match_path_Description" xml:space="preserve">
+    <value>Pfad zusätzlich zum Datei-/Ordnernamen suchen</value>
+  </data>
+  <data name="open_containing_folder" xml:space="preserve">
+    <value>Ordner öffnen (Ctrl+Shift+E)</value>
+  </data>
+  <data name="open_in_console" xml:space="preserve">
+    <value>Pfad in der Konsole öffnen (Ctrl+Shift+C)</value>
+  </data>
+  <data name="plugin_description" xml:space="preserve">
+    <value>Everything-Suchergebnisse anzeigen</value>
+  </data>
+  <data name="plugin_name" xml:space="preserve">
+    <value>Everything</value>
+  </data>
+  <data name="Preview" xml:space="preserve">
+    <value>Vorschau</value>
+  </data>
+  <data name="Preview_Description" xml:space="preserve">
+    <value>Vorschau des Datei-Inhalts als Bild. Kann zum Einfrieren führen, wenn die Datei nicht lokal ist.</value>
+  </data>
+  <data name="QueryText" xml:space="preserve">
+    <value>Abfragetext</value>
+  </data>
+  <data name="QueryText_Description" xml:space="preserve">
+    <value>Ausgewählte Ergebnisse können den Abfragetext aktualisieren. Hilft bei der Anzeige zusätzlicher Informationen, kann aber die Anzeigeergebnisse verändern.</value>
+  </data>
+  <data name="RegEx" xml:space="preserve">
+    <value>RegEx</value>
+  </data>
+  <data name="RegEx_Description" xml:space="preserve">
+    <value>Aktiviert reguläre Ausdrücke in der Suche.</value>
+  </data>
+  <data name="run_as_admin" xml:space="preserve">
+    <value>Als Administrator ausführen (Ctrl+Shift+Enter)</value>
+  </data>
+  <data name="run_as_user" xml:space="preserve">
+    <value>Als anderer Benutzer ausführen (Ctrl+Shift+U)</value>
+  </data>
+  <data name="SwapCopy" xml:space="preserve">
+    <value>Tastenkürzel zum Kopieren tauschen</value>
+  </data>
+  <data name="SwapCopy_Description" xml:space="preserve">
+    <value>Strg+C zum Kopieren von Dateien/Ordnern, Strg+Alt+C zum Kopieren des Pfades.</value>
+  </data>
+</root>

--- a/Properties/Resources.de-de.resx
+++ b/Properties/Resources.de-de.resx
@@ -121,10 +121,16 @@
     <value>Text konnte nicht in die Zwischenablage kopiert werden</value>
   </data>
   <data name="copy_file" xml:space="preserve">
-    <value>Kopieren (Ctrl+C)</value>
+    <value>Kopieren </value>
   </data>
   <data name="copy_path" xml:space="preserve">
-    <value>Pfad kopieren (Ctrl+C)</value>
+    <value>Pfad kopieren </value>
+  </data>
+  <data name="copy_shortcut" xml:space="preserve">
+    <value>(Strg+C)</value>
+  </data>
+  <data name="copy_shortcutAlt" xml:space="preserve">
+    <value>(Strg+Alt+C)</value>
   </data>
   <data name="Everything_ini" xml:space="preserve">
     <value>Everything installieren falls es nicht installiert ist</value>
@@ -142,10 +148,10 @@
     <value>Pfad zusätzlich zum Datei-/Ordnernamen suchen</value>
   </data>
   <data name="open_containing_folder" xml:space="preserve">
-    <value>Ordner öffnen (Ctrl+Shift+E)</value>
+    <value>Ordner öffnen (Strg+Shift+E)</value>
   </data>
   <data name="open_in_console" xml:space="preserve">
-    <value>Pfad in der Konsole öffnen (Ctrl+Shift+C)</value>
+    <value>Pfad in der Konsole öffnen (Strg+Shift+C)</value>
   </data>
   <data name="plugin_description" xml:space="preserve">
     <value>Everything-Suchergebnisse anzeigen</value>
@@ -172,10 +178,10 @@
     <value>Aktiviert reguläre Ausdrücke in der Suche.</value>
   </data>
   <data name="run_as_admin" xml:space="preserve">
-    <value>Als Administrator ausführen (Ctrl+Shift+Enter)</value>
+    <value>Als Administrator ausführen (Strg+Shift+Enter)</value>
   </data>
   <data name="run_as_user" xml:space="preserve">
-    <value>Als anderer Benutzer ausführen (Ctrl+Shift+U)</value>
+    <value>Als anderer Benutzer ausführen (Strg+Shift+U)</value>
   </data>
   <data name="SwapCopy" xml:space="preserve">
     <value>Tastenkürzel zum Kopieren tauschen</value>

--- a/Properties/Resources.de-de.resx
+++ b/Properties/Resources.de-de.resx
@@ -136,7 +136,7 @@
     <value>Ordner konnte nicht geöffnet werden: </value>
   </data>
   <data name="Match_path" xml:space="preserve">
-    <value>Pfad beachten</value>
+    <value>Pfad suchen</value>
   </data>
   <data name="Match_path_Description" xml:space="preserve">
     <value>Pfad zusätzlich zum Datei-/Ordnernamen suchen</value>


### PR DESCRIPTION
Translation for the resource strings in German.

Note: Can't translate keyboard shortcuts because of hardcoded values for `SwapCopy`: `Title = _swapCopy ? ....Replace("Ctrl", "Ctrl+Alt") : ...,`

Maybe @htcfreek wants to make a small review?