### PR TITLE
修复查询结果过多导致powertoys run死掉的BUG

### DIFF
--- a/Everything.cs
+++ b/Everything.cs
@@ -55,7 +55,7 @@ namespace Community.PowerToys.Run.Plugin.Everything
             }
 
             uint resultCount = Everything_GetNumResults();
-
+            resultCount = resultCount > setting.Max ? setting.Max : resultCount;
             for (uint i = 0; i < resultCount; i++)
             {
                 StringBuilder buffer = new StringBuilder(260);


### PR DESCRIPTION
修改前循环次数为搜索的结果数，而不是设置的最大返回结果，当搜索结果过多时，循环耗时具大，导致整个powertoys run 死掉，返回不了任何结果，必须重启