### PR TITLE
解决文件过滤和自带过滤不能同时使用的问题

### DIFF
--- a/Everything.cs
+++ b/Everything.cs
@@ -41,9 +41,21 @@ namespace Community.PowerToys.Run.Plugin.Everything
 
             if (orgqry.Contains(':'))
             {
-                string[] nqry = query.Split(':', 2);
-                if (setting.Filters.TryGetValue(nqry[0].ToLowerInvariant(), out string value))
-                    query = nqry[1].Trim() + " ext:" + value;
+                foreach (var item in setting.Filters.Keys)
+                {
+                    string pattern = @"\b"+ item + ":";
+                    if (Regex.IsMatch(orgqry, pattern, RegexOptions.IgnoreCase))
+                    {
+                        if (!query.Contains("ext:"))
+                        {
+                            query = Regex.Replace(query, pattern, " ext:" + setting.Filters[item] + "; ", RegexOptions.IgnoreCase);
+                        }
+                        else
+                        {
+                            query = Regex.Replace(query, pattern, " ", RegexOptions.IgnoreCase).Replace("ext:", "ext:" + setting.Filters[item] + ";");                            
+                        }
+                    }
+                }
             }
 
             _ = Everything_SetSearchW(query);

--- a/Everything.cs
+++ b/Everything.cs
@@ -41,20 +41,19 @@ namespace Community.PowerToys.Run.Plugin.Everything
 
             if (orgqry.Contains(':'))
             {
-                foreach (var item in setting.Filters.Keys)
+                fStringBuilder sb = new();
+                foreach (var kv in setting.Filters)
                 {
-                    string pattern = @"\b"+ item + ":";
-                    if (Regex.IsMatch(orgqry, pattern, RegexOptions.IgnoreCase))
+                    if (query.Contains(kv.Key, StringComparison.OrdinalIgnoreCase))
                     {
-                        if (!query.Contains("ext:"))
-                        {
-                            query = Regex.Replace(query, pattern, " ext:" + setting.Filters[item] + "; ", RegexOptions.IgnoreCase);
-                        }
-                        else
-                        {
-                            query = Regex.Replace(query, pattern, " ", RegexOptions.IgnoreCase).Replace("ext:", "ext:" + setting.Filters[item] + ";");                            
-                        }
+                        sb.Append(kv.Value + ';');
+                        query = query.Replace(kv.Key, string.Empty);
                     }
+                }
+
+                if (sb.Length > 0)
+                {
+                    query = query.Trim() + " ext:" + sb.ToString();
                 }
             }
 


### PR DESCRIPTION
修改后 pic: size:<2mb demo 和 size:<2mb pic: demo 都可以查询出结果了，另外可以有多个文件过滤，比如 pic: video: demo 可以查询出图片和视频